### PR TITLE
ONB-91 Ensure that each path can have a single traveller for dynamic period of time

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Foundation\Application as FoundationApplication;
+
+class Application extends FoundationApplication
+{
+    protected $namespace = 'App\\';
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
+use App\Application;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/"
+            "Database\\Seeders\\": "database/seeders/",
+            "Paths\\": "paths/"
         }
     },
     "autoload-dev": {

--- a/paths/Controllers/PathController.php
+++ b/paths/Controllers/PathController.php
@@ -5,8 +5,6 @@ namespace Paths\Controllers;
 use Paths\Requests\GetPathsRequest;
 use Paths\Services\PathService;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 
 class PathController extends Controller
 {

--- a/paths/Controllers/PathController.php
+++ b/paths/Controllers/PathController.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace Paths\Controllers;
 
-use App\Http\Requests\GetPathsRequest;
-use App\Services\PathService;
+use Paths\Requests\GetPathsRequest;
+use Paths\Services\PathService;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 

--- a/paths/Controllers/PathLocksController.php
+++ b/paths/Controllers/PathLocksController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Paths\Controllers;
+
+use App\Http\Controllers\Controller;
+use Paths\Services\PathLockingService;
+use Paths\Requests\LockPathRequest;
+use Paths\Requests\ReserveRouteRequest;
+
+class PathLocksController extends Controller
+{
+    public function __construct(
+        private PathLockingService $pathLockingService,
+    ){}
+
+
+    public function reserveRoute(ReserveRouteRequest $request) {
+        $data = $request->validated(); 
+        
+        return $this->pathLockingService->reserveRoute($data['route']);
+    }
+
+    public function lockRoute(LockPathRequest $request){
+        $data = $request->validated();
+
+        return $this->pathLockingService->lockRoute($data['route'], $data['time_to_lock']);
+    }
+
+    public function unlockRoute(ReserveRouteRequest $request){
+        $route =  $request->validated()['route'];
+
+        return $this->pathLockingService->unlockRoute($route);
+    }
+}

--- a/paths/Requests/GetPathsRequest.php
+++ b/paths/Requests/GetPathsRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace Paths\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;

--- a/paths/Requests/LockPathRequest.php
+++ b/paths/Requests/LockPathRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Paths\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LockPathRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'route' => 'required|string', 
+            'time_to_lock' => 'required|numeric',
+            'time_unit' => 'nullable|string',
+        ];
+    }
+}

--- a/paths/Requests/ReserveRouteRequest.php
+++ b/paths/Requests/ReserveRouteRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Paths\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReserveRouteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'route' => 'required'
+        ];
+    }
+}

--- a/paths/Services/PathLockingService.php
+++ b/paths/Services/PathLockingService.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Paths\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class PathLockingService {
+
+      
+  public function reserveRoute(string $route){
+    $cacheKey = $this->getLockCacheKey($route);
+
+    if(Cache::has($cacheKey)){
+        throw new HttpException(423, "Route is already in use");
+    }
+
+    $hops = substr_count($route, '->');
+    
+    $routeComplexity = $this->calculateRoadComplexity($hops, 2);
+
+    return $this->lockRoute($route, $routeComplexity);
+}
+
+private function lockRoute(string $route, int $routeComplexity){
+    $cacheKey = $this->getLockCacheKey($route);
+
+    return Cache::put($cacheKey, true, now()->addHours($routeComplexity));
+}
+
+protected function unlockRoute(string $route){
+    $cacheKey = $this->getLockCacheKey($route);
+
+    return Cache::forget($cacheKey);
+}
+
+private function calculateRoadComplexity(int $hops, int $hoursPerHop){
+    $num = pow($hoursPerHop, $hops);
+    $base = 2; 
+
+    $complexity = log($num, $base);
+
+    return $complexity; 
+}
+
+private function getLockCacheKey(string $route){
+    $transformedString = str_replace(' -> ', '-', $route);
+    $cacheKey = 'lock-' . $transformedString;
+
+    return $cacheKey;
+}
+
+}

--- a/paths/Services/PathService.php
+++ b/paths/Services/PathService.php
@@ -3,7 +3,6 @@
 namespace Paths\Services;
 
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PathService

--- a/paths/Services/PathService.php
+++ b/paths/Services/PathService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services;
+namespace Paths\Services;
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Http\Controllers\PathController;
+use Paths\Controllers\PathController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/paths', [PathController::class, 'getPaths']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,5 +2,9 @@
 
 use Paths\Controllers\PathController;
 use Illuminate\Support\Facades\Route;
+use Paths\Controllers\PathLocksController;
 
 Route::post('/paths', [PathController::class, 'getPaths']);
+Route::post('/paths/reserve-path', [PathLocksController::class, 'reserveRoute']);
+Route::post('/paths/lock-path', [PathLocksController::class, 'lockRoute']);
+Route::post('/paths/unlock-path', [PathLocksController::class, 'unlockRoute']);

--- a/tests/Feature/PathLockingTest.php
+++ b/tests/Feature/PathLockingTest.php
@@ -1,0 +1,128 @@
+<?php
+
+test('Paths can be reserved', function () {
+    $source = 'Tsuchi';
+    $dest = 'Konoha';
+
+    $routesResponse = $this->post('/api/paths', [
+        'source' => $source,
+        'destination' => $dest,
+    ]);
+
+    $routeIndex = random_int(0, count($routesResponse->json()) - 1); // pick random route
+    $route = $routesResponse->json()[$routeIndex]['route']; 
+
+    $reservationResponse = $this->post('/api/paths/reserve-path', [
+        'route' => $route,
+    ]);
+
+    expect($reservationResponse->json()['locked'])->toBe(true);
+    $reservationResponse->assertStatus(200);
+});
+
+
+test('Locked paths cannot be reserved', function () {
+    $source = 'Tsuchi';
+    $dest = 'Mizu';
+
+    $routesResponse = $this->post('/api/paths', [
+        'source' => $source,
+        'destination' => $dest,
+    ]);
+
+    $routeIndex = random_int(0, count($routesResponse->json()) - 1);
+    $route = $routesResponse->json()[$routeIndex]['route']; 
+
+    $this->post('/api/paths/reserve-path', [
+        'route' => $route,
+    ]);
+
+    $reservationResponse2 = $this->post('/api/paths/reserve-path', [
+        'route' => $route,
+    ]);
+
+    $reservationResponse2->assertStatus(423); // Locked HTTP status
+});
+
+test('The API returns the corrects number of hops for the route', function () {
+    $source = 'Tsuchi';
+    $dest = 'Hokage';
+
+    $routesResponse = $this->post('/api/paths', [
+        'source' => $source,
+        'destination' => $dest,
+    ]);
+
+    $routeIndex = random_int(0, count($routesResponse->json()) - 1);
+    $route = $routesResponse->json()[$routeIndex]['route']; 
+    $hopsCount = substr_count($route, ' -> ');
+    $reservationResponse = $this->post('/api/paths/reserve-path', [
+        'route' => $route,
+    ]);
+
+    expect($reservationResponse->json()['number_of_hops'])->toBe($hopsCount);
+    $reservationResponse->assertStatus(200);
+});
+
+
+
+test('Routes can be reserved again after the complexity time passes', function () {
+    $source = 'Tsuchi';
+    $dest = 'Konoha';
+
+    $routesResponse = $this->post('/api/paths', [
+        'source' => $source,
+        'destination' => $dest,
+    ]);
+
+    $routeIndex = random_int(0, count($routesResponse->json()) - 1);
+    $route = $routesResponse->json()[$routeIndex]['route']; 
+
+
+    $reservationResponse = $this->post('/api/paths/reserve-path', [
+        'route' => $route,
+    ]);
+
+    $complexity = $reservationResponse->json()['route_complexity'];
+
+    sleep($complexity); // Pause thread execution
+
+    $reservationResponse2 = $this->post('/api/paths/reserve-path', [
+        'route' => $route,
+    ]);
+
+    expect($reservationResponse2->json()['locked'])->toBe(true);
+    
+
+    $reservationResponse->assertStatus(200);
+    $reservationResponse2->assertStatus(200);
+});
+
+test('Locked routes can be unlocked again', function (){
+
+    $source = 'Tsuchi';
+    $dest = 'Konoha';
+
+    $routesResponse = $this->post('/api/paths', [
+        'source' => $source,
+        'destination' => $dest,
+    ]);
+
+    $routeIndex = random_int(0, count($routesResponse->json()) - 1);
+    $route = $routesResponse->json()[$routeIndex]['route']; 
+
+
+    $lockResponse = $this->post('/api/paths/lock-path', [
+        'route' => $route,
+        'time_to_lock' => 1000000000,
+    ]);
+
+    
+    $unlockResponse = $this->post('/api/paths/unlock-path', [
+        'route' => $route,
+    ]);
+
+    expect( (bool) $unlockResponse->json())->toBeTrue();
+
+    $unlockResponse->assertStatus(200);
+});


### PR DESCRIPTION
Covered test cases: 

1. Paths can be reserved
2. Locked paths cannot be reserved
3. The API returns the right number of hops for the route
4. Routes can be reserved again after the TTL expires;
5. Paths can be unlocked after being locked, even if there is a remaining TTL.

Currently, this only includes the locking logic. The code is agnostic of internal caching mechanisms and is separated from the general PathService. 

Also, inside the test cases, I randomized path-picking (nobody knows which route the application will pick for the test case). 